### PR TITLE
Use https tiles from openstreetmap

### DIFF
--- a/src/frontend/src/app/tracker/map/map.component.ts
+++ b/src/frontend/src/app/tracker/map/map.component.ts
@@ -50,7 +50,7 @@ export class MapComponent implements OnInit {
 
     this.leaflet = map(this.map.nativeElement);
     this.leaflet.setView([49.454105, 9.592735], 6);
-    var layer = tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 15, attribution: 'Open Street Map' });
+    var layer = tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 15, attribution: 'Open Street Map' });
     layer.addTo(this.leaflet);
 
     var current = 0;


### PR DESCRIPTION
When browsing to the site, http resources are loaded. This causes the following to show up:
![image](https://user-images.githubusercontent.com/759160/36102588-0beba4ee-100d-11e8-92d2-d13959ce8364.png)

This PR ensures openstreetmap tiles are loaded over HTTPS instead of HTTP. 

So in essence from:
http://c.tile.openstreetmap.org/6/33/20.png
to
https://c.tile.openstreetmap.org/6/33/20.png